### PR TITLE
Add Request Campaign to Mrkt Marketo Gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ response[:result].each do |result|
 end
 ```
 
+### Run a smart campaign on existing leads
+```ruby
+campaign_id = 42        # this is the ID of the campaign
+lead_ids    = [1, 2, 4] # these are the leads who receive the campaign
+tokens      = [{        # these tokens (optional) are then passed to the campaign
+                 name:  '{{my.message}}',
+                 value: 'Updated message'
+               }, {
+                 name:  '{{my.other token}}',
+                 value: 'Value for other token'
+               }]
+client.request_campaign(campaign_id, lead_ids, tokens) # tokens can be omited
+=> { requestId: 'e42b#14272d07d78', success: true }
+```
 
 ## Run Tests
 

--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -3,6 +3,7 @@ require 'mrkt/errors'
 
 require 'mrkt/concerns/connection'
 require 'mrkt/concerns/authentication'
+require 'mrkt/concerns/crud_helpers'
 require 'mrkt/concerns/crud_leads'
 require 'mrkt/concerns/import_leads'
 
@@ -10,6 +11,7 @@ module Mrkt
   class Client
     include Connection
     include Authentication
+    include CrudHelpers
     include CrudLeads
     include ImportLeads
 

--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -4,6 +4,7 @@ require 'mrkt/errors'
 require 'mrkt/concerns/connection'
 require 'mrkt/concerns/authentication'
 require 'mrkt/concerns/crud_helpers'
+require 'mrkt/concerns/crud_campaigns'
 require 'mrkt/concerns/crud_leads'
 require 'mrkt/concerns/import_leads'
 
@@ -12,6 +13,7 @@ module Mrkt
     include Connection
     include Authentication
     include CrudHelpers
+    include CrudCampaigns
     include CrudLeads
     include ImportLeads
 

--- a/lib/mrkt/concerns/crud_campaigns.rb
+++ b/lib/mrkt/concerns/crud_campaigns.rb
@@ -1,0 +1,16 @@
+module Mrkt
+  module CrudCampaigns
+    def request_campaign(id, lead_ids, tokens = {})
+      post("/rest/v1/campaigns/#{id}/trigger.json") do |req|
+        params = {
+          input: {
+            leads:  lead_ids.map { |id| { id: id } },
+            tokens: tokens
+          }
+        }
+
+        json_payload(req, params)
+      end
+    end
+  end
+end

--- a/lib/mrkt/concerns/crud_helpers.rb
+++ b/lib/mrkt/concerns/crud_helpers.rb
@@ -1,0 +1,8 @@
+module Mrkt
+  module CrudHelpers
+    def json_payload(req, payload)
+      req.headers[:content_type] = 'application/json'
+      req.body = JSON.generate(payload)
+    end
+  end
+end

--- a/lib/mrkt/concerns/crud_leads.rb
+++ b/lib/mrkt/concerns/crud_leads.rb
@@ -32,11 +32,6 @@ module Mrkt
       end
     end
 
-    def json_payload(req, payload)
-      req.headers[:content_type] = 'application/json'
-      req.body = JSON.generate(payload)
-    end
-
     def associate_lead(id, cookie)
       params = Faraday::Utils::ParamsHash.new
       params[:cookie] = cookie

--- a/spec/concerns/crud_campaigns_spec.rb
+++ b/spec/concerns/crud_campaigns_spec.rb
@@ -1,0 +1,71 @@
+describe Mrkt::CrudCampaigns do
+  include_context 'initialized client'
+
+  describe '#request_campaign' do
+    let(:id) { 42 }
+    let(:lead_ids) { [1234, 5678] }
+    let(:tokens) do
+      [{
+         name:  '{{my.message}}',
+         value: 'Updated message'
+       }, {
+         name:  '{{my.other token}}',
+         value: 'Value for other token'
+       }]
+    end
+    subject { client.request_campaign(id, lead_ids, tokens) }
+
+    before do
+      stub_request(:post, "https://#{host}/rest/v1/campaigns/#{id}/trigger.json")
+        .with(body: { input: { leads: lead_ids.map { |id| { id: id } }, tokens: tokens } })
+        .to_return(json_stub(response_stub))
+    end
+
+    context 'with an invalid campaign id' do
+      let(:response_stub) do
+        {
+          requestId: 'a9b#14eb6771358',
+          success:   false,
+          errors:    [{
+                        code:    '1013',
+                        message: 'Campaign not found'
+                      }]
+        }
+      end
+
+      it 'should raise an Error' do
+        expect { subject }.to raise_error(Mrkt::Errors::ObjectNotFound)
+      end
+    end
+
+    context 'with valid campaign id' do
+      context 'with invalid lead id' do
+        let(:response_stub) do
+          {
+            requestId: '7cdc#14eb6ae8a86',
+            success:   false,
+            errors:    [{
+                          code:    '1004',
+                          message: 'Lead [1234] not found'
+                        }]
+          }
+        end
+
+        it 'should raise an Error' do
+          expect { subject }.to raise_error(Mrkt::Errors::LeadNotFound)
+        end
+      end
+
+      context 'for valid lead ids' do
+        let(:response_stub) do
+          {
+            requestId: 'e42b#14272d07d78',
+            success:   true
+          }
+        end
+
+        it { is_expected.to eq(response_stub) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the functionality to request a Smart Campaign for certain leads to our forked Gem "Mrkt" which we will from now on use to make REST requests to Marketo. We need the Smart Campaign feature to trigger emails.